### PR TITLE
doc metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,6 @@ rdev = "0.5.3"
 winapi = { version = "0.3", features = ["winbase", "processenv", "debugapi", "iphlpapi", "iptypes"] }
 ntapi = "0.4.1"
 
+[package.metadata.docs.rs]
+all-features = true
+


### PR DESCRIPTION
Allegedly fixes failure of doc build on crates.io
https://docs.rs/crate/antilysis/0.2.0/builds/1475391